### PR TITLE
Fix documentation error

### DIFF
--- a/sections/api/typescript.md
+++ b/sections/api/typescript.md
@@ -24,7 +24,7 @@ Before you can effectively start to use TypeScript you will have to do a little 
 
 TypeScript definitions for styled-components can be extended by using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) since version `v4.1.4` of the definitions.
 
-So the first step is creating a declarations file. Let's name it `styled.d.ts` for example.
+So the first step is creating a declarations file. Name it `styled.d.ts`.
 
 ```ts
 // import original module declarations


### PR DESCRIPTION
Typescript declaration file extending DefaultTheme *has* to be named styled.d.ts, otherwise the ThemProvider's theme prop type is defined as any, and the theme types are not picked up when accessing the theme object provided by ThemeProvider, as in when doing this:

```
const AuthCardWrapper = styled.div`
  #textHeader {
    color: ${(props) => props.theme.mediaQuery};
  }
`;
```